### PR TITLE
Perf: remove render-blocking CDN assets, fix LCP & a11y landmarks

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: kvs
 permalink: /404.html
 title: "Page not found"
 description: "Looks like there has been a mistake. Nothing exists here."

--- a/_config.yml
+++ b/_config.yml
@@ -278,7 +278,7 @@ enable_panelbear_analytics: false  # enables panelbear analytics
 enable_google_verification: false  # enables google site verification
 enable_bing_verification:   false  # enables bing site verification
 enable_masonry:             false   # enables automatic project cards arangement
-enable_math:                true   # enables math typesetting (uses MathJax)
+enable_math:                false  # enables math typesetting (uses MathJax). Off: no math content on the site; removes a large render/parse cost. Set true to re-enable per the docs.
 enable_tooltips:            false  # enables automatic tooltip links generated
                                    # for each section titles on pages and posts
 enable_darkmode:            true   # enables switching between light/dark modes

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,28 +3,23 @@
 
     <!-- Resource Hints for Performance -->
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     {% if site.enable_google_analytics -%}
     <link rel="preconnect" href="https://www.googletagmanager.com">
     {%- endif %}
+    {%- if page.url == '/' %}
+    <!-- Preload the LCP hero image (homepage) -->
+    <link rel="preload" as="image" href="{{ '/assets/img/prof_pic.jpg' | relative_url }}" fetchpriority="high">
+    {%- endif %}
 
-    <!-- Bootstrap & MDB -->
-    <!-- Bootstrap: Critical for layout, load synchronously -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@{{ site.bootstrap.version }}/dist/css/bootstrap.min.css" rel="stylesheet" integrity="{{ site.bootstrap.integrity.css }}" crossorigin="anonymous">
-    <!-- MDB: Non-critical, defer loading -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mdbootstrap@{{ site.mdb.version }}/css/mdb.min.css" integrity="{{ site.mdb.integrity.css }}" crossorigin="anonymous" media="print" onload="this.media='all'">
-    <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mdbootstrap@{{ site.mdb.version }}/css/mdb.min.css" integrity="{{ site.mdb.integrity.css }}" crossorigin="anonymous"></noscript>
-
-    <!-- Fonts & Icons -->
-    <!-- FontAwesome: Non-critical icons, defer loading -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@{{ site.fontawesome.version }}/css/all.min.css" integrity="{{ site.fontawesome.integrity }}" crossorigin="anonymous" media="print" onload="this.media='all'">
-    <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@{{ site.fontawesome.version }}/css/all.min.css" integrity="{{ site.fontawesome.integrity }}" crossorigin="anonymous"></noscript>
-    <!-- Academicons: Non-critical icons, defer loading -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/academicons@{{ site.academicons.version }}/css/academicons.min.css" integrity="{{ site.academicons.integrity }}" crossorigin="anonymous" media="print" onload="this.media='all'">
-    <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/academicons@{{ site.academicons.version }}/css/academicons.min.css" integrity="{{ site.academicons.integrity }}" crossorigin="anonymous"></noscript>
-    <!-- Google Fonts: Using font-display=swap for performance -->
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Roboto+Slab:100,300,400,500,700|Material+Icons&display=swap">
+    {%- comment -%}
+      The editorial (.kvs) redesign uses self-hosted fonts (_fonts.scss) and its
+      own CSS — it does NOT use Bootstrap, MDBootstrap, FontAwesome, Academicons,
+      or Google Fonts (Roboto). These render-blocking CDN stylesheets were removed
+      to fix the PageSpeed "render-blocking requests" finding. The theme toggle now
+      uses inline SVG instead of FontAwesome glyphs. If a legacy al-folio layout
+      (page/default/post/distill — all currently unpublished) is ever revived, its
+      stylesheets will need to be restored here.
+    {%- endcomment -%}
 
     <!-- Code Syntax Highlighting -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/jwarby/jekyll-pygments-themes@master/{{ site.highlight_theme_light | append: '.css' }}" media="none" id="highlight_theme_light" />

--- a/_includes/kvs_nav.html
+++ b/_includes/kvs_nav.html
@@ -12,7 +12,7 @@
     {%- endfor -%}
     {%- if site.enable_darkmode -%}
     <a id="light-toggle" class="kvs-theme-toggle" role="button" tabindex="0" aria-label="Toggle dark mode" title="Toggle dark mode">
-      <i class="fas fa-moon"></i><i class="fas fa-sun"></i>
+      <svg class="fa-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg><svg class="fa-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
     </a>
     {%- endif -%}
   </div>

--- a/_includes/kvs_nav.html
+++ b/_includes/kvs_nav.html
@@ -12,7 +12,7 @@
     {%- endfor -%}
     {%- if site.enable_darkmode -%}
     <a id="light-toggle" class="kvs-theme-toggle" role="button" tabindex="0" aria-label="Toggle dark mode" title="Toggle dark mode">
-      <svg class="fa-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg><svg class="fa-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+      <svg class="fa-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg><svg class="fa-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
     </a>
     {%- endif -%}
   </div>

--- a/_includes/scripts/mathjax.html
+++ b/_includes/scripts/mathjax.html
@@ -8,5 +8,4 @@
     };
   </script>
   <script defer type="text/javascript" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@{{ site.mathjax.version }}/es5/tex-mml-chtml.js"></script>
-  <script defer src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
   {%- endif %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -49,6 +49,7 @@ layout: kvs
 }
 </script>
 
+<main>
 {%- comment -%} ===================== hero ===================== {%- endcomment -%}
 <section class="kvs-hero">
   <div>
@@ -159,3 +160,4 @@ layout: kvs
     <a href="{{ '/work-with-me/' | relative_url }}">Work with me &rarr;</a>
   </p>
 </section>
+</main>

--- a/_layouts/note.html
+++ b/_layouts/note.html
@@ -20,6 +20,7 @@ layout: kvs
 }
 </script>
 
+<main>
 <div class="kvs-breadcrumb">
   <a href="{{ '/notes/' | relative_url }}">notes</a>
   <span class="sep">/</span>
@@ -58,3 +59,4 @@ layout: kvs
     </p>
   </div>
 </section>
+</main>

--- a/_sass/_kvs.scss
+++ b/_sass/_kvs.scss
@@ -199,7 +199,7 @@ html, body {
 /* inline-SVG toggle icons (replaced FontAwesome). Visibility (display:block/none)
    is still driven by the .fa-sun/.fa-moon rules in _themes.scss per data-theme;
    this only sizes them and overrides FA's icon padding. */
-.kvs-theme-toggle svg { width: 19px; height: 19px; padding: 0; vertical-align: middle; }
+.kvs-theme-toggle svg { width: 22px; height: 22px; padding: 0; vertical-align: middle; }
 
 /* =========================================================
    footer

--- a/_sass/_kvs.scss
+++ b/_sass/_kvs.scss
@@ -199,7 +199,7 @@ html, body {
 /* inline-SVG toggle icons (replaced FontAwesome). Visibility (display:block/none)
    is still driven by the .fa-sun/.fa-moon rules in _themes.scss per data-theme;
    this only sizes them and overrides FA's icon padding. */
-.kvs-theme-toggle svg { width: 16px; height: 16px; padding: 0; vertical-align: middle; }
+.kvs-theme-toggle svg { width: 19px; height: 19px; padding: 0; vertical-align: middle; }
 
 /* =========================================================
    footer

--- a/_sass/_kvs.scss
+++ b/_sass/_kvs.scss
@@ -199,7 +199,7 @@ html, body {
 /* inline-SVG toggle icons (replaced FontAwesome). Visibility (display:block/none)
    is still driven by the .fa-sun/.fa-moon rules in _themes.scss per data-theme;
    this only sizes them and overrides FA's icon padding. */
-.kvs-theme-toggle svg { width: 22px; height: 22px; padding: 0; vertical-align: middle; }
+.kvs-theme-toggle svg { width: 29px; height: 29px; padding: 0; vertical-align: middle; }
 
 /* =========================================================
    footer

--- a/_sass/_kvs.scss
+++ b/_sass/_kvs.scss
@@ -110,7 +110,9 @@ html, body {
 .kvs a {
   color: var(--accent);
   text-decoration: none;
-  border-bottom: 1px solid var(--accent-tint);
+  /* underline strong enough that links don't rely on color alone (a11y:
+     "links rely on color to be distinguishable"). Was --accent-tint (~10%). */
+  border-bottom: 1px solid color-mix(in srgb, var(--accent) 38%, transparent);
   transition: border-color .15s, color .15s;
 }
 .kvs a:hover { color: var(--accent-hover); border-bottom-color: var(--accent); }
@@ -194,6 +196,10 @@ html, body {
   cursor: pointer;
 }
 .kvs-theme-toggle:hover { color: var(--accent); }
+/* inline-SVG toggle icons (replaced FontAwesome). Visibility (display:block/none)
+   is still driven by the .fa-sun/.fa-moon rules in _themes.scss per data-theme;
+   this only sizes them and overrides FA's icon padding. */
+.kvs-theme-toggle svg { width: 16px; height: 16px; padding: 0; vertical-align: middle; }
 
 /* =========================================================
    footer


### PR DESCRIPTION
## Summary

Addresses the PageSpeed Insights audit (mobile Performance **63**, desktop **87**). The dominant issue was ~**3,000 ms** of render-blocking requests on mobile from al-folio CDN assets the editorial (`.kvs`) redesign no longer uses.

**Render-blocking CSS removed from the shared `head.html`** (verified 0 usages in built output):
- MDBootstrap, Google Fonts/Roboto/Material Icons, FontAwesome, Academicons
- Bootstrap — its only consumer was the al-folio 404 page, now converted to the `kvs` layout

**Unused JavaScript:**
- Disabled MathJax (`enable_math: false`) — no math content on the site
- Removed the **polyfill.io** request (sold/compromised domain; also clears the Best-Practices "browser errors logged to console" flag)
- jQuery retained (the publications cite/abstract toggles depend on it)

**LCP (6.9 s mobile):** preload the hero headshot with `fetchpriority="high"` on the homepage — it's a CSS `background-image`, so it was invisible to the preload scanner and only fetched after the render-blocking CSS.

**Accessibility:**
- Added `<main>` landmarks to the home and note layouts ("Document does not have a main landmark")
- Strengthened the body link underline (~10% → ~38% accent) so links don't rely on color alone

**Theme toggle:** replaced the two FontAwesome `<i>` glyphs with inline SVG, keeping the `.fa-moon`/`.fa-sun` class names so the existing `_themes.scss` show/hide-by-theme rules are unchanged.

## Test plan

Verified against a local build + live browser test serving this build:

- [x] `jekyll build` clean
- [x] No bootstrap / mdb / fontawesome / academicons / Google Fonts / MathJax / polyfill in output
- [x] Theme toggle flips `data-theme` and swaps moon/sun icons (light & dark)
- [x] Publications cite/abstract toggles still work (jQuery + common.js)
- [x] No console errors/warnings
- [x] Hero preload, `<main>` landmarks, kvs-based 404 present
- [ ] **Re-run PageSpeed after merge** to confirm gains (expect mobile → ~90s, BP → ~100)

## Note
Legacy al-folio layouts (`page`/`default`/`post`/`distill` — all currently `published: false`) would need their stylesheets restored in `head.html` if ever revived; documented in a comment there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)