### PR TITLE
Perf: serve hero/photos as WebP (fix FCP regression)

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,7 +8,7 @@
     {%- endif %}
     {%- if page.url == '/' %}
     <!-- Preload the LCP hero image (homepage) -->
-    <link rel="preload" as="image" href="{{ '/assets/img/prof_pic.jpg' | relative_url }}" fetchpriority="high">
+    <link rel="preload" as="image" href="{{ '/assets/img/prof_pic-800.webp' | relative_url }}" fetchpriority="high" type="image/webp">
     {%- endif %}
 
     {%- comment -%}

--- a/_layouts/about_page.html
+++ b/_layouts/about_page.html
@@ -5,7 +5,7 @@ layout: kvs
 
 <div class="kvs-about">
   <header class="kvs-about-header">
-    <div class="rail-photo" role="img" aria-label="{{ site.first_name }} {{ site.middle_name }} {{ site.last_name }}" style="background-image: url('{{ '/assets/img/prof_pic.jpg' | relative_url }}');"></div>
+    <div class="rail-photo" role="img" aria-label="{{ site.first_name }} {{ site.middle_name }} {{ site.last_name }}" style="background-image: url('{{ '/assets/img/prof_pic-800.webp' | relative_url }}');"></div>
 
     <div class="kvs-about-meta">
       <div class="eyebrow">Current</div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -70,7 +70,7 @@ layout: kvs
     <a class="biolink" href="{{ '/about/' | relative_url }}">full bio &rarr;</a>
   </div>
 
-  <div class="kvs-hero-photo" role="img" aria-label="{{ site.first_name }} {{ site.middle_name }} {{ site.last_name }}" style="background-image: url('{{ '/assets/img/prof_pic.jpg' | relative_url }}');"></div>
+  <div class="kvs-hero-photo" role="img" aria-label="{{ site.first_name }} {{ site.middle_name }} {{ site.last_name }}" style="background-image: url('{{ '/assets/img/prof_pic-800.webp' | relative_url }}');"></div>
 </section>
 
 <hr style="margin: 40px 0 48px;">

--- a/_layouts/note.html
+++ b/_layouts/note.html
@@ -48,7 +48,7 @@ layout: kvs
 </article>
 
 <section class="kvs-byline">
-  <div class="avatar" role="img" aria-label="{{ site.first_name }} {{ site.middle_name }} {{ site.last_name }}" style="background-image: url('{{ '/assets/img/prof_pic_square.jpg' | relative_url }}');"></div>
+  <div class="avatar" role="img" aria-label="{{ site.first_name }} {{ site.middle_name }} {{ site.last_name }}" style="background-image: url('{{ '/assets/img/prof_pic_square-480.webp' | relative_url }}');"></div>
   <div>
     <div class="name">{{ site.first_name }} {{ site.middle_name }} {{ site.last_name }} <span class="credentials">{{ site.credentials }}</span></div>
     <p>


### PR DESCRIPTION
## Summary

Follow-up to #9. That PR removed the render-blocking CDN assets but its LCP fix preloaded the **145 KB `prof_pic.jpg` at `fetchpriority=high`** — on Lighthouse Slow-4G that ~3s of bandwidth competed with the render-blocking CSS/HTML and kept **FCP at ~4.5s**.

This points the hero, about-page rail photo, the preload, and the note byline avatar at the build's existing WebP variants instead of the raw JPEGs:

- Hero / about / preload → `prof_pic-800.webp` — 800x1200, **33 KB** (was 145 KB; identical resolution, just WebP instead of a bloated JPEG)
- Note avatar → `prof_pic_square-480.webp` — 480x480, ~14 KB (displays in an 80px box = 6x density)

No resolution loss: the source `prof_pic.jpg` is only 800x1200, so the `-800` WebP is the same pixels. The high-priority preload is now ~4x smaller, so it no longer starves FCP, and LCP downloads faster.

## Test plan

- [x] `jekyll build` clean; all four references resolve to generated WebP files
- [x] Hero renders correctly from WebP (verified in browser; 33 KB, 200 OK, image/webp)
- [ ] Re-run PageSpeed after deploy — FCP should drop now that the largest early resource is ~33 KB instead of 145 KB

🤖 Generated with [Claude Code](https://claude.com/claude-code)
